### PR TITLE
Send custom-source voice messages to a single recipient

### DIFF
--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCSession.h
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCSession.h
@@ -259,9 +259,24 @@ typedef NS_ENUM(NSInteger, ZCCReconnectReason) {
 - (ZCCOutgoingVoiceStream *)startVoiceMessageWithSource:(ZCCOutgoingVoiceConfiguration *)sourceConfiguration;
 
 /**
- * Creates a voice stream to a user in the channel, with a custom voice source
+ * @abstract Sends a message to a specific user in the channel with a custom voice source
+ *
+ * @discussion Creates and starts a voice stream to the server using a custom voice source instead
+ * of the device microphone. The Zello Channels SDK maintains a strong reference to the provided
+ * <code>ZCCVoiceSource</code> object until the outgoing stream closes.
+ *
+ * Only the user specified will receive the message.
+ *
+ * @param username the username for the user to send the message to. Other users in the channel won't
+ *                 receive the message.
+ *
+ * @param sourceConfiguration specifies the voice source object for the message
+ *
+ * @return the stream that will be handling the voice message
+ *
+ * @throw NSInvalidArgumentException if <code>sourceConfiguration</code> specifies an unsupported sample rate. Check
+ * <code>ZCCOutgoingVoiceConfiguration.supportedSampleRates</code> for supported sample rates.
  */
-// TODO: Document -startVoiceMessageToUser:source:
 - (ZCCOutgoingVoiceStream *)startVoiceMessageToUser:(NSString *)username source:(ZCCOutgoingVoiceConfiguration *)sourceConfiguration NS_SWIFT_NAME(startVoiceMessage(to:source:));
 
 @end

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCSession.m
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCSession.m
@@ -284,37 +284,34 @@ static void LogWarningForDevelopmentToken(NSString *token) {
 }
 
 - (ZCCOutgoingVoiceStream *)startVoiceMessage {
-  if (!self.readyToSendVoiceMessages) {
-    return nil;
-  }
-
-  return [self startStreamWithConfiguration:nil recipient:nil];
+  return [self startVoiceMessageInternalToUser:nil source:nil];
 }
 
 - (ZCCOutgoingVoiceStream *)startVoiceMessageToUser:(NSString *)username {
-  if (!self.readyToSendVoiceMessages) {
-    return nil;
-  }
-
-  return [self startStreamWithConfiguration:nil recipient:username];
+  return [self startVoiceMessageInternalToUser:username source:nil];
 }
 
 - (ZCCOutgoingVoiceStream *)startVoiceMessageWithSource:(ZCCOutgoingVoiceConfiguration *)sourceConfiguration {
-  // Validate configuration
-  if (![ZCCOutgoingVoiceConfiguration.supportedSampleRates containsObject:@(sourceConfiguration.sampleRate)]) {
-    NSException *parameterException = [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unsupported sampleRate. Check ZCCOutgoingVoiceConfiguration.supportedSampleRates." userInfo:nil];
-    @throw parameterException;
+  return [self startVoiceMessageInternalToUser:nil source:sourceConfiguration];
+}
+
+- (ZCCOutgoingVoiceStream *)startVoiceMessageToUser:(NSString *)username source:(ZCCOutgoingVoiceConfiguration *)sourceConfiguration {
+  return [self startVoiceMessageInternalToUser:username source:sourceConfiguration];
+}
+
+- (ZCCOutgoingVoiceStream *)startVoiceMessageInternalToUser:(nullable NSString *)username source:(nullable ZCCOutgoingVoiceConfiguration *)sourceConfiguration {
+  if (sourceConfiguration) {
+    // Validate configuration
+    if (![ZCCOutgoingVoiceConfiguration.supportedSampleRates containsObject:@(sourceConfiguration.sampleRate)]) {
+      NSException *parameterException = [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unsupported sampleRate. Check ZCCOutgoingVoiceConfiguration.supportedSampleRates." userInfo:nil];
+      @throw parameterException;
+    }
   }
   if (!self.readyToSendVoiceMessages) {
     return nil;
   }
 
-  return [self startStreamWithConfiguration:sourceConfiguration recipient:nil];
-}
-
-- (ZCCOutgoingVoiceStream *)startVoiceMessageToUser:(NSString *)username source:(ZCCOutgoingVoiceConfiguration *)sourceConfiguration {
-  // TODO: Implement -startVoiceMessageToUser:source:
-  return nil;
+  return [self startStreamWithConfiguration:sourceConfiguration recipient:username];
 }
 
 #pragma mark - ZCCVoiceStreamsManagerDelegate

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKitTests/ZCCSessionTests.m
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKitTests/ZCCSessionTests.m
@@ -18,6 +18,7 @@
 #import "ZCCIncomingVoiceStreamInfo+Internal.h"
 #import "ZCCLocationInfo.h"
 #import "ZCCLocationService.h"
+#import "ZCCOutgoingVoiceConfiguration.h"
 #import "ZCCPermissionsManager.h"
 #import "ZCCSocket.h"
 #import "ZCCSocketFactory.h"
@@ -389,6 +390,25 @@
   XCTAssertEqual([XCTWaiter waitForExpectations:@[streamDidEncounterError] timeout:3.0], XCTWaiterResultCompleted);
   OCMVerifyAll(self.socket);
   OCMVerifyAll(self.sessionDelegate);
+}
+
+// Verify that we pass correct parameters when starting a stream with a recipient and a custom source
+- (void)testVoiceMessageToUser_startsStream {
+  OCMStub([self.permissionsManager recordPermission]).andReturn(AVAudioSessionRecordPermissionGranted);
+  ZCCSession *session = [self sessionWithUsername:nil password:nil];
+  [self connectSession:session];
+
+  XCTestExpectation *sentCommand = [[XCTestExpectation alloc] initWithDescription:@"start_stream sent"];
+  OCMExpect([self.socket sendStartStreamWithParams:OCMOCK_ANY recipient:@"bogusUser" callback:OCMOCK_ANY timeoutAfter:30.0]).andDo(^(NSInvocation *invocation) {
+    [sentCommand fulfill];
+  });
+
+  ZCCOutgoingVoiceConfiguration *source = [[ZCCOutgoingVoiceConfiguration alloc] init];
+  source.sampleRate = [ZCCOutgoingVoiceConfiguration.supportedSampleRates firstObject].unsignedIntegerValue;
+  XCTAssertNotNil([session startVoiceMessageToUser:@"bogusUser" source:source]);
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[sentCommand] timeout:3.0], XCTWaiterResultCompleted);
+  OCMVerifyAll(self.socket);
 }
 
 #pragma mark -sendText:


### PR DESCRIPTION
Implements custom-source audio messages to a single recipient and refactors the voice message startup code a little.
