### PR TITLE
ZCCImageMessageManager manages its memory better

### DIFF
--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/images/ZCCIncomingImageInfo.h
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/images/ZCCIncomingImageInfo.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) ZCCImageHeader *header;
 @property (nonatomic, strong, nullable) UIImage *thumbnail;
 @property (nonatomic, strong, nullable) UIImage *image;
+/// The timestamp that this info object was last modified at
+@property (nonatomic, readonly, nonnull) NSDate *lastTouched;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithHeader:(ZCCImageHeader *)header NS_DESIGNATED_INITIALIZER;

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/images/ZCCIncomingImageInfo.m
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/images/ZCCIncomingImageInfo.m
@@ -9,12 +9,42 @@
 #import "ZCCIncomingImageInfo.h"
 #import "ZCCImageHeader.h"
 
-@implementation ZCCIncomingImageInfo
+@interface ZCCIncomingImageInfo ()
+@property (nonatomic, strong, nonnull) NSDate *lastTouched;
+@end
+
+@implementation ZCCIncomingImageInfo {
+  UIImage *_thumbnail;
+  UIImage *_image;
+}
+
 - (instancetype)initWithHeader:(ZCCImageHeader *)header {
   self = [super init];
   if (self) {
     _header = header;
+    _lastTouched = [NSDate date];
   }
   return self;
 }
+
+#pragma mark - Properties
+
+- (UIImage *)image {
+  return _image;
+}
+
+- (void)setImage:(UIImage *)image {
+  _image = image;
+  self.lastTouched = [NSDate date];
+}
+
+- (UIImage *)thumbnail {
+  return _thumbnail;
+}
+
+- (void)setThumbnail:(UIImage *)thumbnail {
+  _thumbnail = thumbnail;
+  self.lastTouched = [NSDate date];
+}
+
 @end


### PR DESCRIPTION
* Stops requiring thumbnails before clearing message from incoming image info cache
* If we don't receive an image for two minutes, remove its metadata from the incoming image info cache
* If we get a low memory warning, remove all thumbnails from the incoming image info cache