### PR TITLE
Better error reporting for server message parse failures

### DIFF
--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCErrors.h
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCErrors.h
@@ -43,6 +43,13 @@ FOUNDATION_EXPORT NSString * const ZCCOSStatusKey;
  */
 FOUNDATION_EXPORT NSString * const ZCCExceptionKey;
 
+/// Value is the message type that we were trying to parse
+FOUNDATION_EXPORT NSString * const ZCCInvalidJSONMessageKey;
+/// Value is the key in the JSON object that we were trying to parse
+FOUNDATION_EXPORT NSString * const ZCCInvalidJSONKeyKey;
+/// Value is the description of the error encountered while trying to parse the JSON object
+FOUNDATION_EXPORT NSString * const ZCCInvalidJSONProblemKey;
+
 /**
  * Error messages sent by the Zello channels server
  */
@@ -132,6 +139,11 @@ typedef NS_ENUM(NSInteger, ZCCErrorCode) {
   ZCCErrorCodeBadCredentials = 1005,
   /// Stream error
   ZCCErrorCodeBusy = 1006,
+  /**
+   * Invalid JSON message from the server. The error's <code>userInfo</code> dictionary will contain
+   * the message as the value for the <code>ZCCServerInvalidMessageKey</code> key.
+   */
+  ZCCErrorCodeInvalidMessage = 1007,
 
   /// Something went wrong in the audio codec layer
   ZCCErrorCodeDecoderUnknown = 2000,

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCErrors.m
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/ZCCErrors.m
@@ -16,6 +16,10 @@ NSString * const ZCCOSStatusKey = @"com.zello.ZCCOSStatusKey";
 NSString * const ZCCServerErrorMessageKey = @"com.zello.ZCCServerErrorMessageKey";
 NSString * const ZCCServerInvalidMessageKey = @"com.zello.ZCCServerInvalidMessageKey";
 
+NSString * const ZCCInvalidJSONMessageKey = @"com.zello.ZCCInvalidJSONMessageKey";
+NSString * const ZCCInvalidJSONKeyKey = @"com.zello.ZCCInvalidJSONKeyKey";
+NSString * const ZCCInvalidJSONProblemKey = @"com.zello.ZCCInvalidJSONProblemKey";
+
 ZCCServerErrorMessage const ZCCServerErrorMessageUnknownCommand = @"unknown command";
 ZCCServerErrorMessage const ZCCServerErrorMessageInternalServerError = @"internal server error";
 ZCCServerErrorMessage const ZCCServerErrorMessageInvalidJSON = @"invalid json";

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKit/network/ZCCSocket.h
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKit/network/ZCCSocket.h
@@ -43,20 +43,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)socket:(ZCCSocket *)socket didReceiveLocationMessage:(ZCCLocationInfo *)location sender:(NSString *)sender;
 
+@optional
 /**
  * Called if we receive a binary message with an unrecognized type byte. data contains the entire
  * data message, including the type byte. If we receive a binary message of length zero, this will
  * be called with type == 0.
  */
-@optional
 - (void)socket:(ZCCSocket *)socket didReceiveData:(NSData *)data unrecognizedType:(NSInteger)type;
 
-/**
- * Called if we receive a text message with an unrecognized format. message contains the entire
- * message.
- */
 @optional
-- (void)socket:(ZCCSocket *)socket didReceiveUnrecognizedMessage:(NSString *)message;
+/**
+ * Called if we receive a message with an unrecognized format, or one that is missing required
+ * parameters.
+ */
+- (void)socket:(ZCCSocket *)socket didEncounterErrorParsingMessage:(NSError *)error;
 
 @end
 

--- a/sdks/ios/ZelloChannelKit/ZelloChannelKitTests/network/ZCCSocketTests.m
+++ b/sdks/ios/ZelloChannelKit/ZelloChannelKitTests/network/ZCCSocketTests.m
@@ -10,6 +10,7 @@
 #import "ZCCSRWebSocket.h"
 #import <XCTest/XCTest.h>
 #import "ZCCAudioSource.h"
+#import "ZCCErrors.h"
 #import "ZCCEncoder.h"
 #import "ZCCEncoderOpus.h"
 #import "ZCCImageHeader.h"
@@ -53,10 +54,19 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
 
 /// Mocked underlying ZCCSRWebSocket
 @property (nonatomic, strong) id webSocket;
+/// Mocked ZCCAudioSource
+@property (nonatomic, strong) id audioSource;
+/// Encoder wrapping the mocked audio source
+@property (nonatomic, strong) ZCCEncoder *encoder;
+/// Stream params specifying the encoder
+@property (nonatomic, strong) ZCCStreamParams *streamParams;
 
 @property (nonatomic, strong) XCTestExpectation *logonCallbackCalled;
 
 @property (nonatomic, strong) ZCCImageMessage *imageMessage;
+@property (nonatomic, readonly) NSDictionary *onStreamStartEvent;
+@property (nonatomic, readonly) NSDictionary *onLocationEvent;
+@property (nonatomic, readonly) NSDictionary *onImageEvent;
 
 @property (nonatomic, readonly) NSDictionary *simpleExpectedLocationCommand;
 @property (nonatomic, readonly) ZCCLocationInfo *simpleLocationInfo;
@@ -75,6 +85,9 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
   self.socket = [[ZCCSocket alloc] initWithURL:[NSURL URLWithString:@"wss://example.com/"] socketFactory:factory];
   self.socketDelegate = OCMProtocolMock(@protocol(ZCCSocketDelegate));
   self.socket.delegate = self.socketDelegate;
+  self.audioSource = OCMProtocolMock(@protocol(ZCCAudioSource));
+  self.encoder = [[ZCCEncoderOpus alloc] initWithRecorder:self.audioSource];
+  self.streamParams = [[ZCCStreamParams alloc] initWithType:@"audio" encoder:self.encoder];
 
   self.logonCallbackCalled = [[XCTestExpectation alloc] initWithDescription:@"Logon callback called"];
 
@@ -97,6 +110,39 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
 
 #pragma mark - Properties
 
+- (NSDictionary *)onImageEvent {
+  return @{@"command":@"on_image",
+           @"channel":@"testChannel",
+           @"from":@"bogusSender",
+           @"message_id":@(3209),
+           @"type":@"jpeg",
+           @"height":@(640),
+           @"width":@(480)};
+}
+
+
+- (NSDictionary *)onLocationEvent {
+  return @{@"command":@"on_location",
+           @"channel":@"test",
+           @"from":@"bogusSender",
+           @"message_id":@(123),
+           @"latitude":@(45.0),
+           @"longitude":@(32.0),
+           @"formatted_address":@"Margaritaville",
+           @"accuracy":@(25.0)};
+}
+
+- (NSDictionary *)onStreamStartEvent {
+  return @{@"command":@"on_stream_start",
+           @"type":@"audio",
+           @"codec":@"opus",
+           @"codec_header":@"Ym9ndXNoZWFkZXIK",
+           @"packet_duration":@(5),
+           @"stream_id":@(12345),
+           @"channel":@"test",
+           @"from":@"bogusSender"};
+}
+
 - (NSDictionary *)simpleExpectedLocationCommand {
   return @{@"command":@"send_location",
            @"seq":@(1),
@@ -115,6 +161,45 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
 
 #pragma mark - Tests
 
+#pragma mark Error reporting
+
+// Verify that we report a malformed JSON object
+- (void)testMalformedJSON_reportsError {
+  XCTestExpectation *reportedError = [[XCTestExpectation alloc] initWithDescription:@"reported error"];
+  OCMExpect([self.socketDelegate socket:self.socket didEncounterErrorParsingMessage:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained NSError *error;
+    [invocation getArgument:&error atIndex:3];
+    XCTAssertEqualObjects(error.domain, ZCCErrorDomain);
+    XCTAssertEqual(error.code, ZCCErrorCodeBadResponse);
+    NSDictionary *userInfo = error.userInfo;
+    XCTAssertEqualObjects(userInfo[ZCCServerInvalidMessageKey], @"{\"start a message and then...");
+    [reportedError fulfill];
+  });
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:@"{\"start a message and then..."];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[reportedError] timeout:3.0], XCTWaiterResultCompleted);
+  OCMVerifyAll(self.socketDelegate);
+}
+
+// Verify that we report a JSON object with a missing or unrecognized command
+- (void)testMalformedJSON_missingCommand_reportsError {
+  NSString *command = @"{\"someKey\":\"someValue\"}";
+  [self verifyInvalidCommand:nil message:command reportsErrorForKey:@"command" description:@"command missing or not string"];
+}
+
+- (void)testMalformedJSON_unrecognizedCommand_reportsError {
+  NSString *command = @"{\"command\":\"unused\"}";
+  [self verifyInvalidCommand:@"unused" message:command reportsErrorForKey:@"command" description:@"unrecognized command"];
+}
+
+// Verify that we report an error parsing the error message from a server error event
+- (void)testOnError_missingErrorMessage_reportsError {
+  NSString *event = @"{\"command\":\"on_error\"}";
+  [self verifyInvalidCommand:@"on_error" message:event reportsErrorForKey:@"error" description:@"error missing or not string"];
+}
+
+#pragma mark Websocket
+
 // Verify that -open opens the web socket
 - (void)testOpen_opensWebSocket {
   [self.socket open];
@@ -128,6 +213,8 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
 
   OCMVerify([self.webSocket close]);
 }
+
+#pragma mark Logon
 
 // Verify that -logon... sends the correct values to the server
 - (void)testLogon_sendsCorrectCommand {
@@ -337,6 +424,72 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
   OCMVerifyAll(self.webSocket);
 }
 
+// Verify error for missing image id in send_image response
+- (void)testSendImage_responseMissingImageId_reportsError {
+  XCTestExpectation *commandSent = [[XCTestExpectation alloc] initWithDescription:@"send_image sent"];
+  OCMExpect([self.webSocket sendString:OCMOCK_ANY error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [commandSent fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *callbackCalled = [[XCTestExpectation alloc] initWithDescription:@"callback called"];
+  [self.socket sendImage:self.imageMessage callback:^(BOOL succeeded, UInt32 imageId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(imageId, 0);
+    XCTAssertEqualObjects(errorMessage, @"image_id missing or invalid");
+    [callbackCalled fulfill];
+  } timeoutAfter:30.0];
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[commandSent] timeout:3.0], XCTWaiterResultCompleted);
+
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:@"{\"seq\":1,\"success\":true}"];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[callbackCalled] timeout:3.0], XCTWaiterResultCompleted);
+  OCMVerifyAll(self.webSocket);
+}
+
+// Verify error for image id underflow in send_image response
+- (void)testSendImage_responseImageIdUnderflow_reportsError {
+  XCTestExpectation *commandSent = [[XCTestExpectation alloc] initWithDescription:@"send_image sent"];
+  OCMExpect([self.webSocket sendString:OCMOCK_ANY error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [commandSent fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *callbackCalled = [[XCTestExpectation alloc] initWithDescription:@"callback called"];
+  [self.socket sendImage:self.imageMessage callback:^(BOOL succeeded, UInt32 imageId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(imageId, 0);
+    XCTAssertEqualObjects(errorMessage, @"image_id (-1) out of range");
+    [callbackCalled fulfill];
+  } timeoutAfter:30.0];
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[commandSent] timeout:3.0], XCTWaiterResultCompleted);
+
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:@"{\"seq\":1,\"success\":true,\"image_id\":-1}"];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[callbackCalled] timeout:3.0], XCTWaiterResultCompleted);
+  OCMVerifyAll(self.webSocket);
+}
+
+// Verify error for image id overflow in send_image response
+- (void)testSendImage_responseImageIdOverflow_reportsError {
+  XCTestExpectation *commandSent = [[XCTestExpectation alloc] initWithDescription:@"send_image sent"];
+  OCMExpect([self.webSocket sendString:OCMOCK_ANY error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [commandSent fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *callbackCalled = [[XCTestExpectation alloc] initWithDescription:@"callback called"];
+  [self.socket sendImage:self.imageMessage callback:^(BOOL succeeded, UInt32 imageId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(imageId, 0);
+    XCTAssertEqualObjects(errorMessage, @"image_id (17179869184) out of range");
+    [callbackCalled fulfill];
+  } timeoutAfter:30.0];
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[commandSent] timeout:3.0], XCTWaiterResultCompleted);
+
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:@"{\"seq\":1,\"success\":true,\"image_id\":17179869184}"];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[callbackCalled] timeout:3.0], XCTWaiterResultCompleted);
+  OCMVerifyAll(self.webSocket);
+}
+
 // Verify that we send image data
 - (void)testSendImageData_sendsDataMessages {
   uint8_t idata[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -374,6 +527,82 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
 
   XCTAssertEqual([XCTWaiter waitForExpectations:@[calledDelegate] timeout:3.0], XCTWaiterResultCompleted);
   OCMVerifyAll(self.socketDelegate);
+}
+
+// Verify that we propagate errors for invalid image header messages
+// Verify error for missing sender
+- (void)testOnImage_missingSender_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSString *event = [self onImageEventWithoutKey:@"from"];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"from" description:@"from missing or invalid"];
+}
+
+// Verify error for missing image id
+- (void)testOnImage_missingImageId_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSString *event = [self onImageEventWithoutKey:@"message_id"];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"message_id" description:@"message_id missing or invalid"];
+}
+
+// Verify error for image id underflow
+- (void)testOnImage_imageIdUnderflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"message_id"] = @(-1);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"message_id" description:@"message_id out of range"];
+}
+
+// Verify error for image id overflow
+- (void)testOnImage_imageIdOverflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"message_id"] = @(1ll << 34);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"message_id" description:@"message_id out of range"];
+}
+
+// Verify error for missing type
+- (void)testOnImage_missingType_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSString *event = [self onImageEventWithoutKey:@"type"];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"type" description:@"type missing or invalid"];
+}
+
+// Verify error for height underflow
+- (void)testOnImage_heightUnderflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"height"] = @(-1);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"height" description:@"height out of range"];
+}
+
+// Verify error for height overflow
+- (void)testOnImage_heightOverflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"height"] = @(1ll << 34);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"height" description:@"height out of range"];
+}
+
+// Verify error for width underflow
+- (void)testOnImage_widthUnderflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"width"] = @(-1);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"width" description:@"width out of range"];
+}
+
+// Verify error for width overflow
+- (void)testOnImage_widthOverflow_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveImageHeader:OCMOCK_ANY]);
+  NSMutableDictionary *oob = [self.onImageEvent mutableCopy];
+  oob[@"width"] = @(1ll << 34);
+  NSString *event = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_image" message:event reportsErrorForKey:@"width" description:@"width out of range"];
 }
 
 // Verify that we propagate image data events
@@ -420,13 +649,173 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
     return messageIsEqualToDictionary(message, expected);
   }] error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andReturn(YES);
 
-  id recorder = OCMProtocolMock(@protocol(ZCCAudioSource));
-  ZCCEncoder *encoder = [[ZCCEncoderOpus alloc] initWithRecorder:recorder];
-  ZCCStreamParams *params = [[ZCCStreamParams alloc] initWithType:@"audio" encoder:encoder];
-  [self.socket sendStartStreamWithParams:params recipient:@"bogusUser" callback:^(BOOL succeeded, NSUInteger streamId, NSString * _Nullable errorMessage) {
+  [self.socket sendStartStreamWithParams:self.streamParams recipient:@"bogusUser" callback:^(BOOL succeeded, NSUInteger streamId, NSString * _Nullable errorMessage) {
   } timeoutAfter:30.0];
 
   OCMVerifyAll(self.webSocket);
+}
+
+// Verify error for missing stream id in start_stream response
+- (void)testStartStream_responseMissingStreamId_reportsError {
+  NSDictionary *startStream = @{@"command":@"start_stream",
+                                @"seq":@(1),
+                                @"type":@"audio",
+                                @"codec":@"opus",
+                                @"codec_header":@"QB8BPA==",
+                                @"packet_duration":@(60)};
+  XCTestExpectation *sentStart = [[XCTestExpectation alloc] initWithDescription:@"sent stream_start"];
+  OCMStub([self.webSocket sendString:[OCMArg checkWithBlock:^BOOL(NSString *message) {
+    return messageIsEqualToDictionary(message, startStream);
+  }] error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [sentStart fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *reportedError = [[XCTestExpectation alloc] initWithDescription:@"reported error"];
+  [self.socket sendStartStreamWithParams:self.streamParams recipient:nil callback:^(BOOL succeeded, NSUInteger streamId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(streamId, 0);
+    XCTAssertEqualObjects(errorMessage, @"stream_id missing or invalid");
+    [reportedError fulfill];
+  } timeoutAfter:30.0];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[sentStart] timeout:3.0], XCTWaiterResultCompleted);
+  NSString *response = @"{\"seq\":1,\"success\":true}";
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:response];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[reportedError] timeout:3.0], XCTWaiterResultCompleted);
+}
+
+// Verify error for stream id underflow in start_stream response
+- (void)testStartStream_streamIdUnderflow_reportsError {
+  NSDictionary *startStream = @{@"command":@"start_stream",
+                                @"seq":@(1),
+                                @"type":@"audio",
+                                @"codec":@"opus",
+                                @"codec_header":@"QB8BPA==",
+                                @"packet_duration":@(60)};
+  XCTestExpectation *sentStart = [[XCTestExpectation alloc] initWithDescription:@"sent stream_start"];
+  OCMStub([self.webSocket sendString:[OCMArg checkWithBlock:^BOOL(NSString *message) {
+    return messageIsEqualToDictionary(message, startStream);
+  }] error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [sentStart fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *reportedError = [[XCTestExpectation alloc] initWithDescription:@"reported error"];
+  [self.socket sendStartStreamWithParams:self.streamParams recipient:nil callback:^(BOOL succeeded, NSUInteger streamId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(streamId, 0);
+    XCTAssertEqualObjects(errorMessage, @"stream_id out of range");
+    [reportedError fulfill];
+  } timeoutAfter:30.0];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[sentStart] timeout:3.0], XCTWaiterResultCompleted);
+  NSString *response = @"{\"seq\":1,\"success\":true,\"stream_id\":-2}";
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:response];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[reportedError] timeout:3.0], XCTWaiterResultCompleted);
+}
+
+// Verify error for stream id overflow in start_stream response
+- (void)testStartStream_streamIdOverflow_reportsError {
+  NSDictionary *startStream = @{@"command":@"start_stream",
+                                @"seq":@(1),
+                                @"type":@"audio",
+                                @"codec":@"opus",
+                                @"codec_header":@"QB8BPA==",
+                                @"packet_duration":@(60)};
+  XCTestExpectation *sentStart = [[XCTestExpectation alloc] initWithDescription:@"sent stream_start"];
+  OCMStub([self.webSocket sendString:[OCMArg checkWithBlock:^BOOL(NSString *message) {
+    return messageIsEqualToDictionary(message, startStream);
+  }] error:(NSError * __autoreleasing *)[OCMArg anyPointer]]).andDo(^(NSInvocation *invocation) {
+    [sentStart fulfill];
+  }).andReturn(YES);
+
+  XCTestExpectation *reportedError = [[XCTestExpectation alloc] initWithDescription:@"reported error"];
+  [self.socket sendStartStreamWithParams:self.streamParams recipient:nil callback:^(BOOL succeeded, NSUInteger streamId, NSString * _Nullable errorMessage) {
+    XCTAssertFalse(succeeded);
+    XCTAssertEqual(streamId, 0);
+    XCTAssertEqualObjects(errorMessage, @"stream_id out of range");
+    [reportedError fulfill];
+  } timeoutAfter:30.0];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[sentStart] timeout:3.0], XCTWaiterResultCompleted);
+  NSString *response = @"{\"seq\":1,\"success\":true,\"stream_id\":17179869184}";
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:response];
+
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[reportedError] timeout:3.0], XCTWaiterResultCompleted);
+}
+
+// Verify that we report errors parsing the stream start event
+- (void)testOnStreamStart_missingType_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"type"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"type" description:@"type is missing or invalid"];
+}
+
+- (void)testOnStreamStart_missingCodec_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"codec"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"codec" description:@"codec is missing or invalid"];
+}
+
+- (void)testOnStreamStart_missingCodecHeader_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"codec_header"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"codec_header" description:@"codec_header missing or invalid"];
+}
+
+- (void)testOnStreamStart_missingPacketDuration_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"packet_duration"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"packet_duration" description:@"packet_duration missing or not a number"];
+}
+
+- (void)testOnStreamStart_packetDurationUnderflow_reportsError {
+  NSMutableDictionary *outOfBounds = [self.onStreamStartEvent mutableCopy];
+  outOfBounds[@"packet_duration"] = @(-1);
+  NSString *command = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:outOfBounds options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"packet_duration" description:@"packet_duration out of range"];
+}
+
+- (void)testOnStreamStart_missingStreamId_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"stream_id"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"stream_id" description:@"stream_id missing or invalid"];
+}
+
+- (void)testOnStreamStart_streamIdUnderflow_reportsError {
+  NSMutableDictionary *oob = [self.onStreamStartEvent mutableCopy];
+  oob[@"stream_id"] = @(-1);
+  NSString *command = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"stream_id" description:@"stream_id out of range"];
+}
+
+- (void)testOnStreamStart_streamIdOverflow_reportsError {
+  NSMutableDictionary *oob = [self.onStreamStartEvent mutableCopy];
+  oob[@"stream_id"] = @(1ll << 34);
+  NSString *command = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:oob options:0 error:NULL] encoding:NSUTF8StringEncoding];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"stream_id" description:@"stream_id out of range"];
+}
+
+- (void)testOnStreamStart_missingChannel_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"channel"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"channel" description:@"channel missing or invalid"];
+}
+
+- (void)testOnStreamStart_missingSender_reportsError {
+  NSString *command = [self onStreamStartEventWithoutKey:@"from"];
+  [self verifyInvalidCommand:@"on_stream_start" message:command reportsErrorForKey:@"from" description:@"from missing or invalid"];
+}
+
+// Verify that we report errors parsing the stream stop event
+- (void)testOnStreamStop_missingStreamId_reportsError {
+  NSString *command = @"{\"command\":\"on_stream_stop\"}";
+  [self verifyInvalidCommand:@"on_stream_stop" message:command reportsErrorForKey:@"stream_id" description:@"stream_id missing or invalid"];
+}
+
+- (void)testOnStreamStop_streamIdUnderflow_reportsError {
+  NSString *command = @"{\"command\":\"on_stream_stop\",\"stream_id\":-3}";
+  [self verifyInvalidCommand:@"on_stream_stop" message:command reportsErrorForKey:@"stream_id" description:@"stream_id out of range"];
+}
+
+- (void)testOnStreamStop_streamIdOverflow_reportsError {
+  NSString *command = @"{\"command\":\"on_stream_stop\",\"stream_id\":17179869184}";
+  [self verifyInvalidCommand:@"on_stream_stop" message:command reportsErrorForKey:@"stream_id" description:@"stream_id out of range"];
 }
 
 #pragma mark Locations
@@ -559,6 +948,31 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
   OCMVerifyAll(self.socketDelegate);
 }
 
+// TODO: Verify error reporting for invalid location events
+- (void)testReceiveLocation_missingLatitude_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveLocationMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
+  NSString *command = [self onLocationEventWithoutKey:@"latitude"];
+  [self verifyInvalidCommand:@"on_location" message:command reportsErrorForKey:@"latitude" description:@"latitude missing or invalid"];
+}
+
+- (void)testReceiveLocation_missingLongitude_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveLocationMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
+  NSString *command = [self onLocationEventWithoutKey:@"longitude"];
+  [self verifyInvalidCommand:@"on_location" message:command reportsErrorForKey:@"longitude" description:@"longitude missing or invalid"];
+}
+
+- (void)testReceiveLocation_missingAccuracy_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveLocationMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
+  NSString *command = [self onLocationEventWithoutKey:@"accuracy"];
+  [self verifyInvalidCommand:@"on_location" message:command reportsErrorForKey:@"accuracy" description:@"accuracy missing or invalid"];
+}
+
+- (void)testReceiveLocation_missingSender_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveLocationMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
+  NSString *command = [self onLocationEventWithoutKey:@"from"];
+  [self verifyInvalidCommand:@"on_location" message:command reportsErrorForKey:@"from" description:@"from missing or invalid"];
+}
+
 #pragma mark Texting
 
 // Verify that we send the right command for a text to the whole channel
@@ -665,29 +1079,55 @@ static BOOL messageIsEqualToDictionary(NSString *message, NSDictionary *expected
   OCMVerifyAll(self.socketDelegate);
 }
 
-- (void)testReceiveText_invalidMessages {
-  // Missing message text
+- (void)testReceiveText_missingText_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveTextMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
   NSString *event = @"{\"command\":\"on_text_message\",\"channel\":\"exampleChannel\",\"from\":\"exampleSender\",\"message_id\":1234}";
-  XCTestExpectation *posted = [[XCTestExpectation alloc] initWithDescription:@"delegate called"];
-  OCMExpect([self.socketDelegate socket:self.socket didReceiveUnrecognizedMessage:event]).andDo(^(NSInvocation *invocation) {
-    [posted fulfill];
+  [self verifyInvalidCommand:@"on_text_message" message:event reportsErrorForKey:@"text" description:@"text missing or invalid"];
+}
+
+- (void)testReceiveText_missingSender_reportsError {
+  OCMReject([self.socketDelegate socket:OCMOCK_ANY didReceiveTextMessage:OCMOCK_ANY sender:OCMOCK_ANY]);
+  NSString *event = @"{\"command\":\"on_text_message\",\"channel\":\"exampleChannel\",\"message_id\":1234,\"text\":\"my test message\"}";
+  [self verifyInvalidCommand:@"on_text_message" message:event reportsErrorForKey:@"from" description:@"from missing or invalid"];
+}
+
+#pragma mark - Utilities
+
+- (NSString *)onImageEventWithoutKey:(NSString *)key {
+  NSMutableDictionary *event = [self.onImageEvent mutableCopy];
+  event[key] = nil;
+  return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:event options:0 error:NULL] encoding:NSUTF8StringEncoding];
+}
+
+- (NSString *)onStreamStartEventWithoutKey:(NSString *)key {
+  NSMutableDictionary *event = [self.onStreamStartEvent mutableCopy];
+  event[key] = nil;
+  return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:event options:0 error:nil] encoding:NSUTF8StringEncoding];
+}
+
+- (NSString *)onLocationEventWithoutKey:(NSString *)key {
+  NSMutableDictionary *event = [self.onLocationEvent mutableCopy];
+  event[key] = nil;
+  return [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:event options:0 error:NULL] encoding:NSUTF8StringEncoding];
+}
+
+- (void)verifyInvalidCommand:(NSString *)commandName message:(NSString *)commandMessage reportsErrorForKey:(NSString *)key description:(NSString *)errorDescription {
+  XCTestExpectation *reportedError = [[XCTestExpectation alloc] initWithDescription:@"reported error"];
+  OCMStub([self.socketDelegate socket:self.socket didEncounterErrorParsingMessage:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained NSError *error;
+    [invocation getArgument:&error atIndex:3];
+    XCTAssertEqualObjects(error.domain, ZCCErrorDomain);
+    XCTAssertEqual(error.code, ZCCErrorCodeInvalidMessage);
+    NSDictionary *userInfo = error.userInfo;
+    XCTAssertEqualObjects(userInfo[ZCCServerInvalidMessageKey], commandMessage);
+    XCTAssertEqualObjects(userInfo[ZCCInvalidJSONMessageKey], commandName);
+    XCTAssertEqualObjects(userInfo[ZCCInvalidJSONKeyKey], key);
+    XCTAssertEqualObjects(userInfo[ZCCInvalidJSONProblemKey], errorDescription);
+    [reportedError fulfill];
   });
+  [self.socket webSocket:self.webSocket didReceiveMessageWithString:commandMessage];
 
-  [self.socket webSocket:self.webSocket didReceiveMessageWithString:event];
-
-  XCTAssertEqual([XCTWaiter waitForExpectations:@[posted] timeout:3.0], XCTWaiterResultCompleted);
-  OCMVerifyAll(self.socketDelegate);
-
-  event = @"{\"command\":\"on_text_message\",\"channel\":\"exampleChannel\",\"message_id\":1234,\"text\":\"my test message\"}";
-  XCTestExpectation *again = [[XCTestExpectation alloc] initWithDescription:@"delegate called"];
-  OCMExpect([self.socketDelegate socket:self.socket didReceiveUnrecognizedMessage:event]).andDo(^(NSInvocation *invocation) {
-    [again fulfill];
-  });
-
-  [self.socket webSocket:self.webSocket didReceiveMessageWithString:event];
-
-  XCTAssertEqual([XCTWaiter waitForExpectations:@[again] timeout:3.0], XCTWaiterResultCompleted);
-  OCMVerifyAll(self.socketDelegate);
+  XCTAssertEqual([XCTWaiter waitForExpectations:@[reportedError] timeout:3.0], XCTWaiterResultCompleted);
 }
 
 @end


### PR DESCRIPTION
We report more information back to the user if something goes wrong parsing a message from the server. Hopefully this will help us better understand problems they may run into.